### PR TITLE
Revert PostgreSQL switch and document migration plan

### DIFF
--- a/DATABASE_MIGRATION.md
+++ b/DATABASE_MIGRATION.md
@@ -1,0 +1,69 @@
+# Database Migration Plan: MariaDB to PostgreSQL
+
+This document captures the current understanding of the persistence layer and lays out the plan for migrating Basango's backend from MariaDB 10.11 to PostgreSQL 16. It will evolve as the Doctrine mappings and migrations are adapted for PostgreSQL-specific capabilities.
+
+## 1. Current Storage Footprint
+
+* Doctrine connects to MariaDB through `DATABASE_URL` defined in `.env` and environment overrides. The URL is currently `mysql://root:root@mariadb:3306/app?serverVersion=Mariadb-10.11.11&charset=utf8mb4`.
+* Custom Doctrine DBAL types (`article_id`, `open_graph`, etc.) are registered in `config/packages/doctrine.yaml`. These will continue to work with PostgreSQL as they are platform-agnostic, but their SQL declarations must be verified once the platform switches.
+* Article persistence relies on MySQL-specific generated columns for `image` and `excerpt`, and maintains indexes on `hash`, `publishedAt`, and `publishedAt + id` for cursor pagination. JSON is stored via the custom `open_graph` type.
+* Feed management tables (`bookmark`, `comment`, etc.) rely on boolean defaults stored as `0/1` and on cascaded relations that will need to be expressed with PostgreSQL `ON DELETE` behaviour.
+
+## 2. Design Goals for the PostgreSQL Schema
+
+1. Preserve all existing data while enabling PostgreSQL features needed by the product roadmap (full-text search, advanced indexing, vector similarity, etc.).
+2. Replace MySQL-specific constructs:
+   * Convert generated columns to PostgreSQL generated columns or materialized expressions (e.g. `image` JSON path extraction can use `GENERATED ALWAYS AS ((metadata->>'image')) STORED`).
+   * Revisit boolean defaults (`DEFAULT FALSE/TRUE`) instead of `0/1`.
+   * Use `JSONB` for `open_graph` payloads.
+3. Optimise pagination and search:
+   * Create a descending composite index on `(published_at DESC, id DESC)` to support cursor-based feeds.
+   * Evaluate trigram (`pg_trgm`) or GIN indexes for text-heavy fields (`title`, `body`, `comment.content`) as part of future search features.
+4. Leverage UUIDs or native sequences as appropriate. Current IDs are custom types backed by strings; confirm compatibility or migrate to `UUID` columns if a future mapping change adopts them.
+5. Ensure all `ON DELETE CASCADE` relationships continue working and enforce them with foreign keys in PostgreSQL.
+
+## 3. Migration Workflow
+
+1. **Preparation**
+   * Freeze application writes or enable maintenance mode.
+   * Capture a final MariaDB snapshot using the existing `bin/backup.sh` script (it currently runs `mysqldump`). Extend it later to dump PostgreSQL once cut-over is complete.
+   * Provision the target PostgreSQL cluster (version ≥ 16) with sufficient disk and I/O.
+   * Enable required extensions on the target database (`pg_trgm`, `unaccent`, `uuid-ossp`, `pgcrypto`, `vector`) as they become necessary for new features.
+
+2. **Schema Translation**
+   * Generate Doctrine migration diffs against PostgreSQL to obtain the base schema.
+   * Manually adjust the generated migrations to:
+     - Replace column definitions for custom generated columns and JSON data.
+     - Introduce explicit collations if case-insensitive comparisons are required.
+     - Define indexes (including descending and GIN/GIST indexes) tailored to PostgreSQL.
+   * Version these migrations but defer execution until the data transfer is complete.
+
+3. **Data Transfer**
+   * Use the new `projects/backend/bin/migration.sh` helper with the production connection strings to run `pgloader` (or equivalent) from MariaDB to PostgreSQL.
+   * Validate row counts and checksum critical tables after the load.
+   * Rebuild sequences or UUID generators if the Doctrine mappings change.
+
+4. **Post-Load Migration**
+   * Execute Doctrine migrations against PostgreSQL to create indexes, generated columns, and constraints that `pgloader` could not translate.
+   * Run integrity checks (foreign keys, uniqueness).
+   * Recompute derived data if needed (e.g. if the excerpt column becomes a materialized value stored via trigger or generated column).
+
+5. **Application Cut-over**
+   * Update environment variables (`DATABASE_URL`, Docker compose definitions, CI secrets) to point to PostgreSQL.
+   * Deploy code that contains PostgreSQL-specific mappings and migrations.
+   * Run `bin/console cache:clear` and smoke test core flows (ingesting articles, bookmarking, commenting, authentication).
+   * Monitor logs and metrics; keep the MariaDB snapshot for rollback until stability is confirmed.
+
+## 4. Testing & Validation Strategy
+
+* Automated: run the Symfony test suite and linters against a PostgreSQL database to surface platform-specific issues.
+* Manual: verify API endpoints that rely on time-based pagination to ensure the descending index behaves as expected.
+* Performance: benchmark feed queries, full-text search prototypes, and vector similarity routines once indexes are in place.
+
+## 5. Open Questions / TODOs
+
+* Confirm how custom DBAL types serialize/deserialise when mapped to PostgreSQL column types (e.g. ensure `open_graph` becomes `JSONB`).
+* Decide whether to retain the string-based identifiers or transition to native UUID columns while switching databases.
+* Determine if additional data transformations are required for timezone handling when migrating `datetime_immutable` columns.
+* Document rollback procedures once the PostgreSQL migration is complete.
+

--- a/projects/backend/bin/migration.sh
+++ b/projects/backend/bin/migration.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONSOLE_BIN="$PROJECT_ROOT/bin/console"
+APPLY_MIGRATIONS=0
+PGLOADER_EXTRA_ARGS=()
+SOURCE_DSN=""
+TARGET_DSN=""
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options] <mariadb_dsn> <postgres_dsn>
+
+Environment variables:
+  SOURCE_DATABASE_URL   MariaDB connection string (fallback for <mariadb_dsn>)
+  TARGET_DATABASE_URL   PostgreSQL connection string (fallback for <postgres_dsn>)
+
+Options:
+  --apply-migrations    Run Doctrine migrations after data transfer (uses local PHP runtime)
+  --pgloader-arg ARG    Append a raw argument when calling pgloader (can be provided multiple times)
+  -h, --help            Show this help message
+
+Examples:
+  SOURCE_DATABASE_URL="mysql://user:pass@host/db" \\
+  TARGET_DATABASE_URL="postgresql://user:pass@host/db" \\
+  $(basename "$0") --apply-migrations
+
+  $(basename "$0") --pgloader-arg "--with no schema" \\
+  mysql://root:root@127.0.0.1:3306/app \\
+  postgresql://app:secret@127.0.0.1:5432/app
+USAGE
+}
+
+log() {
+  printf '[migration] %s\n' "$*"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply-migrations)
+      APPLY_MIGRATIONS=1
+      ;;
+    --pgloader-arg)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "--pgloader-arg requires a value" >&2
+        exit 1
+      fi
+      PGLOADER_EXTRA_ARGS+=("$1")
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      if [[ -z "$SOURCE_DSN" ]]; then
+        SOURCE_DSN="$1"
+      elif [[ -z "$TARGET_DSN" ]]; then
+        TARGET_DSN="$1"
+      else
+        PGLOADER_EXTRA_ARGS+=("$1")
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$SOURCE_DSN" ]]; then
+  SOURCE_DSN="${SOURCE_DATABASE_URL:-}"
+fi
+if [[ -z "$TARGET_DSN" ]]; then
+  TARGET_DSN="${TARGET_DATABASE_URL:-}"
+fi
+
+if [[ -z "$SOURCE_DSN" || -z "$TARGET_DSN" ]]; then
+  echo "Source and target DSNs are required (pass as arguments or set SOURCE_DATABASE_URL/TARGET_DATABASE_URL)." >&2
+  usage >&2
+  exit 1
+fi
+
+if ! command -v pgloader >/dev/null 2>&1; then
+  echo "pgloader is required but not available on PATH. Install it (https://pgloader.readthedocs.io) and retry." >&2
+  exit 1
+fi
+
+log "Starting data copy"
+log "  source : $SOURCE_DSN"
+log "  target : $TARGET_DSN"
+
+pgloader "${PGLOADER_EXTRA_ARGS[@]}" "$SOURCE_DSN" "$TARGET_DSN"
+
+log "Data copy finished"
+
+if [[ $APPLY_MIGRATIONS -eq 1 ]]; then
+  if ! command -v php >/dev/null 2>&1; then
+    echo "PHP CLI is required to run Doctrine migrations." >&2
+    exit 1
+  fi
+
+  if [[ ! -x "$CONSOLE_BIN" ]]; then
+    echo "Symfony console not found at $CONSOLE_BIN" >&2
+    exit 1
+  fi
+
+  log "Running Doctrine migrations"
+  (cd "$PROJECT_ROOT" && php "$CONSOLE_BIN" doctrine:migrations:migrate --no-interaction)
+fi
+
+log "Migration helper completed"


### PR DESCRIPTION
## Summary
- revert the previous PostgreSQL migration changes to restore the MariaDB-oriented configuration
- document the MariaDB to PostgreSQL migration strategy in DATABASE_MIGRATION.md for future work
- add a portable migration.sh helper that runs pgloader via connection strings and can optionally apply Doctrine migrations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3f1063064832baff10724e89d3515